### PR TITLE
fix: add missing file argument to pickle.dump when saving embeddings

### DIFF
--- a/notebook.ipynb
+++ b/notebook.ipynb
@@ -2670,7 +2670,7 @@
    "outputs": [],
    "source": [
     "with open('embeddings.bin', 'wb') as f_out:\n",
-    "    pickle.dump(embeddings)"
+    "    pickle.dump(embeddings, f_out)"
    ]
   },
   {


### PR DESCRIPTION
### Summary
This PR fixes an issue in the embeddings saving code where `pickle.dump` was called with only one argument. The function requires both the object to be saved and the file handle. Without the second argument, it raises:

TypeError: dump() missing required argument 'file' (pos 2)

Why this is needed?

1. Prevents runtime errors when saving embeddings.
2. Ensures embeddings are correctly serialized to disk and can be reloaded later using pickle.load.